### PR TITLE
Topic page with related articles

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -4,11 +4,13 @@ const newsAppAPI = axios.create({
   baseURL: 'https://news-app-ugpw.onrender.com/api',
 });
 
-export const getAllArticles = async () => {
+export const getAllArticles = async (topicQueryParam) => {
   try {
     const {
       data: { articles },
-    } = await newsAppAPI.get('/articles');
+    } = await newsAppAPI.get('/articles', {
+      params: { topic: topicQueryParam },
+    });
     return articles;
   } catch (error) {
     console.error('error getting articles', error);

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -4,15 +4,19 @@ import ArticleContainer from './ArticlesContainer.jsx';
 import Header from './Header.jsx';
 import Article from './Article.jsx';
 import { UserProvider } from '../contexts/User.jsx';
+import ArticleByTopic from './ArticleByTopic.jsx';
+import NavBar from './NavBar.jsx';
 
 function App() {
   return (
     <>
       <UserProvider>
         <Header />
+        <NavBar />
         <Routes>
           <Route path="/" element={<ArticleContainer />} />
           <Route path="/articles/:article_id" element={<Article />} />
+          <Route path="/articles" element={<ArticleByTopic />} />
         </Routes>
       </UserProvider>
     </>

--- a/src/components/Article.jsx
+++ b/src/components/Article.jsx
@@ -1,4 +1,4 @@
-import { useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router-dom';
 import { getArticleById } from '../api';
 import { useEffect, useState } from 'react';
 import { formatDate } from '../utils/utils';
@@ -48,9 +48,10 @@ function Article() {
   return (
     <div>
       <h1>{title}</h1>
-      <h2>
+      <h2 className="text-right">
         Posted by: {author} on {formatDate(created_at)}
       </h2>
+
       <img
         className="rounded-md w-full h-40"
         src={article_img_url}

--- a/src/components/Article.jsx
+++ b/src/components/Article.jsx
@@ -1,4 +1,4 @@
-import { useLocation } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { getArticleById } from '../api';
 import { useEffect, useState } from 'react';
 import { formatDate } from '../utils/utils';
@@ -6,13 +6,19 @@ import CommentContainer from './CommentContainer';
 import VotingContainer from './VotingContainer';
 
 function Article() {
-  const location = useLocation();
-  const { article_id } = location.state;
+  const { article_id } = useParams();
   const [error, setError] = useState(null);
   const [isLoading, setIsLoading] = useState(false);
   const [articleDetails, setArticleDetails] = useState({});
-  const { title, author, created_at, article_img_url, body, comment_count } =
-    articleDetails;
+  const {
+    title,
+    author,
+    created_at,
+    article_img_url,
+    body,
+    comment_count,
+    votes,
+  } = articleDetails;
 
   useEffect(() => {
     setError(null);
@@ -52,7 +58,7 @@ function Article() {
       />
       <p>{body}</p>
       <h2>Comments: {comment_count}</h2>
-      <VotingContainer />
+      <VotingContainer votes={votes} />
       <CommentContainer />
     </div>
   );

--- a/src/components/ArticleByTopic.jsx
+++ b/src/components/ArticleByTopic.jsx
@@ -1,0 +1,28 @@
+import { getAllArticles } from '../api';
+import ArticleCard from './ArticleCard';
+import useApiRequest from '../hooks/useApiRequest';
+import { useSearchParams } from 'react-router-dom';
+function ArticleByTopic() {
+  const [searchParams] = useSearchParams();
+  const topic = searchParams.get('topic');
+  const { data, isLoading, error } = useApiRequest(getAllArticles, topic);
+
+  if (isLoading) {
+    return <h1>Loading Articles....</h1>;
+  }
+  if (error) {
+    return <Error error={error} />;
+  }
+  return (
+    <>
+      <h1>{topic}</h1>
+      <section className="flex flex-wrap gap-3 justify-center">
+        {data.map((article) => {
+          return <ArticleCard article={article} key={article.article_id} />;
+        })}
+      </section>
+    </>
+  );
+}
+
+export default ArticleByTopic;

--- a/src/components/ArticlesContainer.jsx
+++ b/src/components/ArticlesContainer.jsx
@@ -3,7 +3,7 @@ import ArticlesList from './ArticlesList';
 function ArticlesContainer() {
   return (
     <section>
-      <h1 className="m-5">Articles</h1>
+      <h1 className="m-5">All Articles</h1>
       <ArticlesList />
     </section>
   );

--- a/src/components/CommentAdder.jsx
+++ b/src/components/CommentAdder.jsx
@@ -1,11 +1,10 @@
 import { useContext, useRef, useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { UserContext } from '../contexts/User';
 import { postNewComment } from '../api';
 
 function CommentAdder({ setFetchCommentsTrigger }) {
-  const location = useLocation();
-  const { article_id } = location.state;
+  const { article_id } = useParams();
   const { currentUser } = useContext(UserContext);
   const [error, setError] = useState(null);
   const [success, setSuccess] = useState(null);

--- a/src/components/CommentList.jsx
+++ b/src/components/CommentList.jsx
@@ -1,12 +1,11 @@
-import { useLocation } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { getCommentsByArticleId } from '../api';
 import useApiRequest from '../hooks/useApiRequest';
 import CommentCard from './CommentCard';
 import { useState } from 'react';
 
 function CommentList({ fetchCommentsTrigger }) {
-  const location = useLocation();
-  const { article_id } = location.state;
+  const { article_id } = useParams();
   const [commentDeleted, setCommentDeleted] = useState(0);
   const [statusMessage, setStatusMessage] = useState('');
   const { data, isLoading, error } = useApiRequest(

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -1,0 +1,22 @@
+import { Link } from 'react-router-dom';
+
+function NavBar() {
+  return (
+    <section className="border-b-4">
+      <Link to="/">
+        <button>Article list</button>
+      </Link>
+      <Link to={`/articles?topic=football`}>
+        <button>Football</button>
+      </Link>
+      <Link to={`/articles?topic=cooking`}>
+        <button>Cooking</button>
+      </Link>
+      <Link to={`/articles?topic=coding`}>
+        <button>Coding</button>
+      </Link>
+    </section>
+  );
+}
+
+export default NavBar;

--- a/src/components/VotingContainer.jsx
+++ b/src/components/VotingContainer.jsx
@@ -1,10 +1,9 @@
 import { useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { patchUpOrDownVote } from '../api';
 
-function VotingContainer() {
-  const location = useLocation();
-  const { votes, article_id } = location.state;
+function VotingContainer({ votes }) {
+  const { article_id } = useParams();
   const [error, setError] = useState(null);
   const [voteCount, setVoteCount] = useState(0);
 


### PR DESCRIPTION
Ability view pages filtered by topics
- added a nav bar to move between pages that filter articles by individual or all topics
- nav bar stays visible at all times
- swapped out the usage of useLocation with useParams & useSearchParams to allow the routing directly to individual articles or topic pages
- some minor styling tweaks