### PR TITLE
remove start app from test workflow

### DIFF
--- a/.github/workflows/prod.yaml
+++ b/.github/workflows/prod.yaml
@@ -6,6 +6,21 @@ on:
       - main # Change this if your main branch has a different name
 
 jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout repo
+        uses: actions/checkout@v3
+
+      - name: Use Node.js
+        uses: actions/setup-node@v2
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run functional/unit tests
+        run: npm t
   build-and-deploy:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
removing the step to start the app from the test step in ci/cd, this is not needed for these tests