### PR TITLE
removing step to log api_url during deployment

### DIFF
--- a/.github/workflows/stg.yaml
+++ b/.github/workflows/stg.yaml
@@ -40,10 +40,10 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
-      - name: Check API URL (debug)
-        run: echo "VITE_API_URL = $VITE_API_URL"
+
       - name: Build Project
         run: npm run build
+
       - name: Deploy to Netlify
         run: |
           npm install -g netlify-cli


### PR DESCRIPTION
step for logging vite_api_url no longer needed