### PR TITLE
installing crtf reporter for playwright for usage in build pipeline

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,4 @@ e2e
 planning
 README.md
 .vscode
+ctrf

--- a/.github/workflows/stg.yaml
+++ b/.github/workflows/stg.yaml
@@ -86,3 +86,6 @@ jobs:
           report-path: ./ctrf/ctrfReport.json
           summary: true
           pull-request: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        if: always()

--- a/.github/workflows/stg.yaml
+++ b/.github/workflows/stg.yaml
@@ -58,6 +58,8 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     needs: build-deploy
+    permissions:
+      pull-requests: write
     env:
       ENV: staging
       BASE_URL: ${{ secrets.BASE_URL_STAGING }}
@@ -85,7 +87,7 @@ jobs:
         with:
           report-path: ./ctrf/ctrfReport.json
           summary: true
-          pull-request: true
+          pull-request-report: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         if: always()

--- a/.github/workflows/stg.yaml
+++ b/.github/workflows/stg.yaml
@@ -81,4 +81,8 @@ jobs:
           path: playwright-report/
           retention-days: 30
       - name: Publish Test Summary Results
-        run: npx github-actions-ctrf ctrf/ctrfReport.json
+        uses: ctrf-io/github-test-reporter@v1
+        with:
+          report-path: ./ctrf/ctrfReport.json
+          summary: true
+          pull-request: true

--- a/.github/workflows/stg.yaml
+++ b/.github/workflows/stg.yaml
@@ -80,3 +80,5 @@ jobs:
           name: playwright-report
           path: playwright-report/
           retention-days: 30
+      - name: Publish Test Summary Results
+        run: npx github-actions-ctrf ctrf/ctrf-report.json

--- a/.github/workflows/stg.yaml
+++ b/.github/workflows/stg.yaml
@@ -81,4 +81,4 @@ jobs:
           path: playwright-report/
           retention-days: 30
       - name: Publish Test Summary Results
-        run: npx github-actions-ctrf ctrf/ctrf-report.json
+        run: npx github-actions-ctrf ctrf/ctrfReport.json

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ dist-ssr
 
 # Testing
 playwright-report
+ctrf
 
 # Editor directories and files
 .vscode

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "globals": "^15.15.0",
         "jsdom": "^26.1.0",
         "msw": "^2.10.2",
+        "playwright-ctrf-json-reporter": "^0.0.23",
         "prettier": "^3.6.2",
         "typescript": "^5.9.2",
         "vite": "^6.2.0",
@@ -20442,6 +20443,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/playwright-ctrf-json-reporter": {
+      "version": "0.0.23",
+      "resolved": "https://registry.npmjs.org/playwright-ctrf-json-reporter/-/playwright-ctrf-json-reporter-0.0.23.tgz",
+      "integrity": "sha512-49e1gSdq7Rytz9ji8kwgrrWZ0w39RNVDH5FlPiBeosdn12VTfWmhYRBcKpC2D29pa1ZdTxGhHdbB4UML2MNITg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "globals": "^15.15.0",
     "jsdom": "^26.1.0",
     "msw": "^2.10.2",
+    "playwright-ctrf-json-reporter": "^0.0.23",
     "prettier": "^3.6.2",
     "typescript": "^5.9.2",
     "vite": "^6.2.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -30,7 +30,11 @@ export default defineConfig({
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'html',
+  reporter: [
+    ['html', { outputFile: 'test-results/jsonReport.json' }],
+    ['junit', { outputFile: 'test-results/junitReport.xml' }],
+    ['playwright-ctrf-json-reporter', { outputFile: 'ctrfReport.json' }],
+  ],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */


### PR DESCRIPTION
Improving the report visibility for the e2e tests

- creating a json & junit report for future scenarios
- installed ctrf report as a dev dependency
- use ctrf report in github actions to publish the test results for each run regardless of pass/fail